### PR TITLE
feat: websockets and graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This package comes with a couple of goodies that should be mentioned, first is t
     - [@SkipThrottle()](#skipthrottle)
   - [Ignoring specific user agents](#ignoring-specific-user-agents)
   - [ThrottlerStorage](#throttlerstorage)
+  - [Working with Websockets](#working-with-websockets)
+  - [Working with GraphQL](#working-with-graphql)
 - [Community Storage Providers](#community-storage-providers)
 
 # Usage
@@ -182,6 +184,25 @@ export interface ThrottlerStorage {
 ```
 
 So long as the Storage service implements this interface, it should be usable by the `ThrottlerGuard`.
+
+## Working with Websockets
+
+To get the `ThrottlerModule` working with websockets, not much is needed besides regular
+configuration. The things to make note of are that 1) you cannot bind the guard with
+`APP_GUARD` or `app.useGlobalGuards()` due to how Nest binds global guards and 2) when a limit is
+reached, Nest will emit an `exception` event, so make sure there is a listener ready for this.
+Other than that, no extra configuration is needed.
+
+## Working with GraphQL
+
+To get the `ThrottlerModule` to work with the GraphQL context, a couple of things must happen.
+First, you must use `Express` and `apollo-server-express` as your GraphQL server engine. This is
+the default for Nest, but the [`apollo-server-fastify`](https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-fastify) package
+does not currently support passing `res` to the `context`, meaning headers cannot be properly set.
+Second, when configuring your `GraphQLModule`, you need to pass an option for `context` in the form
+of `({ req, res}) => ({ req, res })`. This will allow access to the Express Request and Response
+objects, allowing for the reading and writing of headers. Other than that, no other actions are
+needed, just bind the guard and you'll be good to go.
 
 # Community Storage Providers
 

--- a/README.md
+++ b/README.md
@@ -187,22 +187,20 @@ So long as the Storage service implements this interface, it should be usable by
 
 ## Working with Websockets
 
-To get the `ThrottlerModule` working with websockets, not much is needed besides regular
-configuration. The things to make note of are that 1) you cannot bind the guard with
-`APP_GUARD` or `app.useGlobalGuards()` due to how Nest binds global guards and 2) when a limit is
-reached, Nest will emit an `exception` event, so make sure there is a listener ready for this.
-Other than that, no extra configuration is needed.
+There are some things to take keep in mind when working with websockets:
+
+- You cannot bind the guard with `APP_GUARD` or `app.useGlobalGuards()` due to how Nest binds global guards.
+- When a limit is reached, Nest will emit an `exception` event, so make sure there is a listener ready for this.
 
 ## Working with GraphQL
 
 To get the `ThrottlerModule` to work with the GraphQL context, a couple of things must happen.
-First, you must use `Express` and `apollo-server-express` as your GraphQL server engine. This is
-the default for Nest, but the [`apollo-server-fastify`](https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-fastify) package
-does not currently support passing `res` to the `context`, meaning headers cannot be properly set.
-Second, when configuring your `GraphQLModule`, you need to pass an option for `context` in the form
-of `({ req, res}) => ({ req, res })`. This will allow access to the Express Request and Response
-objects, allowing for the reading and writing of headers. Other than that, no other actions are
-needed, just bind the guard and you'll be good to go.
+
+- You must use `Express` and `apollo-server-express` as your GraphQL server engine. This is
+  the default for Nest, but the [`apollo-server-fastify`](https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-fastify) package does not currently support passing `res` to the `context`, meaning headers cannot be properly set.
+- When configuring your `GraphQLModule`, you need to pass an option for `context` in the form
+  of `({ req, res}) => ({ req, res })`. This will allow access to the Express Request and Response
+  objects, allowing for the reading and writing of headers.
 
 # Community Storage Providers
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@typescript-eslint/eslint-plugin": "^3.1.0",
     "@typescript-eslint/parser": "^3.1.0",
     "apollo-server-express": "^2.14.3",
+    "apollo-server-fastify": "^2.14.3",
     "conventional-changelog-cli": "^2.0.31",
     "cz-conventional-changelog": "^3.1.0",
     "eslint": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -89,15 +89,7 @@
     "ts-node": "^8.6.2",
     "tsconfig-paths": "^3.9.0",
     "typescript": "^3.7.4",
-    "ws": "^7.3.0",
-    "reflect-metadata": "^0.1.13",
-    "@nestjs/common": "^7.0.0",
-    "@nestjs/core": "^7.0.0"
-  },
-  "peerDependencies": {
-    "@nestjs/common": "^7.0.0",
-    "@nestjs/core": "^7.0.0",
-    "reflect-metadata": "^0.1.13"
+    "ws": "^7.3.0"
   },
   "peerDependencies": {
     "@nestjs/common": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@nestjs/platform-express": "^7.0.0",
     "@nestjs/platform-fastify": "^7.1.1",
     "@nestjs/platform-socket.io": "^7.1.2",
-    "@nestjs/platform-ws": "^7.1.2",
+    "@nestjs/platform-ws": "^7.1.3",
     "@nestjs/schematics": "^7.0.0",
     "@nestjs/testing": "^7.0.0",
     "@nestjs/websockets": "^7.1.2",
@@ -87,7 +87,8 @@
     "ts-loader": "^7.0.5",
     "ts-node": "^8.6.2",
     "tsconfig-paths": "^3.9.0",
-    "typescript": "^3.7.4"
+    "typescript": "^3.7.4",
+    "ws": "^7.3.0"
   },
   "peerDependencies": {
     "@nestjs/common": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,15 @@
     "ts-node": "^8.6.2",
     "tsconfig-paths": "^3.9.0",
     "typescript": "^3.7.4",
-    "ws": "^7.3.0"
+    "ws": "^7.3.0",
+    "reflect-metadata": "^0.1.13",
+    "@nestjs/common": "^7.0.0",
+    "@nestjs/core": "^7.0.0"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^7.0.0",
+    "@nestjs/core": "^7.0.0",
+    "reflect-metadata": "^0.1.13"
   },
   "peerDependencies": {
     "@nestjs/common": "^7.0.0",

--- a/src/throttle.decorator.ts
+++ b/src/throttle.decorator.ts
@@ -1,10 +1,10 @@
 import { THROTTLER_LIMIT, THROTTLER_SKIP, THROTTLER_TTL } from './throttler.constants';
 
-function setThrottlerMetadata(target: () => any, limit: number, ttl: number): void {
-  Reflect.defineMetadata(THROTTLER_LIMIT, limit, target);
-  Reflect.defineMetadata(THROTTLER_TTL, ttl, target);
-}
-
+/**
+ * Adds metadata to the target which will be handled by the ThrottlerGuard to
+ * handle incoming requests based on the given metadata.
+ * @usage @Throttle(2, 10)
+ */
 export const Throttle = (limit = 20, ttl = 60): MethodDecorator & ClassDecorator => {
   return (
     target: any,
@@ -12,14 +12,22 @@ export const Throttle = (limit = 20, ttl = 60): MethodDecorator & ClassDecorator
     descriptor?: TypedPropertyDescriptor<any>,
   ) => {
     if (descriptor) {
-      setThrottlerMetadata(descriptor.value, limit, ttl);
+      Reflect.defineMetadata(THROTTLER_LIMIT, limit, descriptor.value);
+      Reflect.defineMetadata(THROTTLER_TTL, ttl, descriptor.value);
       return descriptor;
     }
-    setThrottlerMetadata(target, limit, ttl);
+    Reflect.defineMetadata(THROTTLER_LIMIT, limit, target);
+    Reflect.defineMetadata(THROTTLER_TTL, ttl, target);
     return target;
   };
 };
 
+/**
+ * Adds metadata to the target which will be handled by the ThrottlerGuard
+ * whether or not to skip throttling for this context.
+ * @usage @SkipThrottle()
+ * @usage @SkipThrottle(false)
+ */
 export const SkipThrottle = (skip = true): MethodDecorator & ClassDecorator => {
   return (
     target: any,

--- a/src/throttle.decorator.ts
+++ b/src/throttle.decorator.ts
@@ -1,5 +1,10 @@
 import { THROTTLER_LIMIT, THROTTLER_SKIP, THROTTLER_TTL } from './throttler.constants';
 
+function setThrottlerMetadata(target: any, limit: number, ttl: number): void {
+  Reflect.defineMetadata(THROTTLER_TTL, ttl, target);
+  Reflect.defineMetadata(THROTTLER_LIMIT, limit, target);
+}
+
 /**
  * Adds metadata to the target which will be handled by the ThrottlerGuard to
  * handle incoming requests based on the given metadata.
@@ -12,12 +17,10 @@ export const Throttle = (limit = 20, ttl = 60): MethodDecorator & ClassDecorator
     descriptor?: TypedPropertyDescriptor<any>,
   ) => {
     if (descriptor) {
-      Reflect.defineMetadata(THROTTLER_LIMIT, limit, descriptor.value);
-      Reflect.defineMetadata(THROTTLER_TTL, ttl, descriptor.value);
+      setThrottlerMetadata(descriptor.value, limit, ttl);
       return descriptor;
     }
-    Reflect.defineMetadata(THROTTLER_LIMIT, limit, target);
-    Reflect.defineMetadata(THROTTLER_TTL, ttl, target);
+    setThrottlerMetadata(target, limit, ttl);
     return target;
   };
 };

--- a/src/throttler-storage.interface.ts
+++ b/src/throttler-storage.interface.ts
@@ -10,13 +10,13 @@ export interface ThrottlerStorage {
   /**
    * Get a record via its key and return all its request ttls.
    */
-  getRecord(key: string): number[] | undefined;
+  getRecord(key: string): Promise<number[]>;
 
   /**
    * Add a record to the storage. The record will automatically be removed from
    * the storage once its TTL has been reached.
    */
-  addRecord(key: string, ttl: number): void;
+  addRecord(key: string, ttl: number): Promise<void>;
 }
 
 export const ThrottlerStorage = Symbol('ThrottlerStorage');

--- a/src/throttler-storage.interface.ts
+++ b/src/throttler-storage.interface.ts
@@ -1,6 +1,22 @@
 export interface ThrottlerStorage {
-  getRecord(key: string): Promise<number[]>;
-  addRecord(key: string, ttl: number): Promise<void>;
+  /**
+   * The internal storage with all the request records.
+   * The key is a hashed key based on the current context and IP.
+   * The value of each item wil be an array of Date objects which indicate all
+   * the request's ttls in an ascending order.
+   */
+  storage: Record<string, Date[]>;
+
+  /**
+   * Get a record via its key and return all its request ttls.
+   */
+  getRecord(key: string): Date[] | undefined;
+
+  /**
+   * Add a record to the storage. The record will automatically be removed from
+   * the storage once its TTL has been reached.
+   */
+  addRecord(key: string, ttl: number): void;
 }
 
 export const ThrottlerStorage = Symbol('ThrottlerStorage');

--- a/src/throttler-storage.interface.ts
+++ b/src/throttler-storage.interface.ts
@@ -2,15 +2,15 @@ export interface ThrottlerStorage {
   /**
    * The internal storage with all the request records.
    * The key is a hashed key based on the current context and IP.
-   * The value of each item wil be an array of Date objects which indicate all
+   * The value of each item wil be an array of epoch times which indicate all
    * the request's ttls in an ascending order.
    */
-  storage: Record<string, Date[]>;
+  storage: Record<string, number[]>;
 
   /**
    * Get a record via its key and return all its request ttls.
    */
-  getRecord(key: string): Date[] | undefined;
+  getRecord(key: string): number[] | undefined;
 
   /**
    * Add a record to the storage. The record will automatically be removed from

--- a/src/throttler.exception.ts
+++ b/src/throttler.exception.ts
@@ -3,12 +3,20 @@ import { WsException } from '@nestjs/websockets';
 
 const message = 'Too Many Requests';
 
+/**
+ * Throws a HttpException with a 429 status code, indicating that too many
+ * requests were being fired within a certain time window.
+ */
 export class ThrottlerException extends HttpException {
   constructor() {
     super(`ThrottlerException: ${message}`, HttpStatus.TOO_MANY_REQUESTS);
   }
 }
 
+/**
+ * Throws a WsException indicating that too many requests were being fired
+ * within a certain time window.
+ */
 export class ThrottlerWsException extends WsException {
   constructor() {
     super(`ThrottlerWsException: ${message}`);

--- a/src/throttler.exception.ts
+++ b/src/throttler.exception.ts
@@ -1,7 +1,14 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
 
 export class ThrottlerException extends HttpException {
   constructor() {
     super('ThrottlerException: Too Many Requests', HttpStatus.TOO_MANY_REQUESTS);
+  }
+}
+
+export class ThrottlerWsException extends WsException {
+  constructor() {
+    super('ThrottlerWsException: Too Many Requests');
   }
 }

--- a/src/throttler.exception.ts
+++ b/src/throttler.exception.ts
@@ -1,14 +1,16 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { WsException } from '@nestjs/websockets';
 
+const message = 'Too Many Requests';
+
 export class ThrottlerException extends HttpException {
   constructor() {
-    super('ThrottlerException: Too Many Requests', HttpStatus.TOO_MANY_REQUESTS);
+    super(`ThrottlerException: ${message}`, HttpStatus.TOO_MANY_REQUESTS);
   }
 }
 
 export class ThrottlerWsException extends WsException {
   constructor() {
-    super('ThrottlerWsException: Too Many Requests');
+    super(`ThrottlerWsException: ${message}`);
   }
 }

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -6,7 +6,7 @@ import {
   THROTTLER_LIMIT,
   THROTTLER_OPTIONS,
   THROTTLER_SKIP,
-  THROTTLER_TTL
+  THROTTLER_TTL,
 } from './throttler.constants';
 import { ThrottlerException } from './throttler.exception';
 import { ThrottlerOptions } from './throttler.interface';

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -118,8 +118,8 @@ export class ThrottlerGuard implements CanActivate {
   ): Promise<boolean> {
     const client = context.switchToWs().getClient();
     const ip = ['conn', '_socket']
-      .map(key => client[key])
-      .filter(obj => obj)
+      .map((key) => client[key])
+      .filter((obj) => obj)
       .shift().remoteAddress;
     const key = this.generateKey(context, ip);
     const ttls = await this.storageService.getRecord(key);

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -79,9 +79,8 @@ export class ThrottlerGuard implements CanActivate {
     // Here we start to check the amount of requests being done against the ttl.
     const res = context.switchToHttp().getResponse();
     const key = this.generateKey(context, req.ip);
-    const ttls = await this.storageService.getRecord(key);
-    const nearestExpiryTime =
-      ttls.length > 0 ? Math.ceil((ttls[0].getTime() - new Date().getTime()) / 1000) : 0;
+    const ttls = this.storageService.getRecord(key);
+    const nearestExpiryTime = ttls.length > 0 ? Math.ceil((ttls[0] - Date.now()) / 1000) : 0;
 
     // Throw an error when the user reached their limit.
     if (ttls.length >= limit) {

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -8,7 +8,7 @@ import {
   THROTTLER_SKIP,
   THROTTLER_TTL,
 } from './throttler.constants';
-import { ThrottlerException } from './throttler.exception';
+import { ThrottlerException, ThrottlerWsException } from './throttler.exception';
 import { ThrottlerOptions } from './throttler.interface';
 
 @Injectable()
@@ -125,7 +125,7 @@ export class ThrottlerGuard implements CanActivate {
     const ttls = await this.storageService.getRecord(key);
 
     if (ttls.length >= limit) {
-      throw new ThrottlerException();
+      throw new ThrottlerWsException();
     }
 
     await this.storageService.addRecord(key, ttl);

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -141,6 +141,11 @@ export class ThrottlerGuard implements CanActivate {
     ttl: number,
   ): Promise<boolean> {
     const { req, res } = context.getArgByIndex(2);
+    // add in escape route for GQL Fastify
+    // and for if res is not added to the context.
+    if (!res) {
+      return true;
+    }
     const httpContext: ExecutionContext = {
       ...context,
       switchToHttp: () => ({

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -85,6 +85,7 @@ export class ThrottlerGuard implements CanActivate {
     const headerPrefix = 'X-RateLimit';
 
     // Here we start to check the amount of requests being done against the ttl.
+    const req = context.switchToHttp().getRequest();
     const res = context.switchToHttp().getResponse();
     const key = this.generateKey(context, req.ip);
     const ttls = await this.storageService.getRecord(key);

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -6,7 +6,7 @@ import {
   THROTTLER_LIMIT,
   THROTTLER_OPTIONS,
   THROTTLER_SKIP,
-  THROTTLER_TTL,
+  THROTTLER_TTL
 } from './throttler.constants';
 import { ThrottlerException, ThrottlerWsException } from './throttler.exception';
 import { ThrottlerOptions } from './throttler.interface';
@@ -57,6 +57,8 @@ export class ThrottlerGuard implements CanActivate {
         return this.httpHandler(context, limit, ttl);
       case 'ws':
         return this.websocketHandler(context, limit, ttl);
+      default:
+        return true;
     }
   }
 

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -6,7 +6,7 @@ import {
   THROTTLER_LIMIT,
   THROTTLER_OPTIONS,
   THROTTLER_SKIP,
-  THROTTLER_TTL
+  THROTTLER_TTL,
 } from './throttler.constants';
 import { ThrottlerException, ThrottlerWsException } from './throttler.exception';
 import { ThrottlerOptions } from './throttler.interface';
@@ -53,8 +53,10 @@ export class ThrottlerGuard implements CanActivate {
     const ttl = routeOrClassTtl || this.options.ttl;
 
     switch (context.getType()) {
-      case 'http': return this.httpHandler(context, limit, ttl);
-      case 'ws': return this.websocketHandler(context, limit, ttl);
+      case 'http':
+        return this.httpHandler(context, limit, ttl);
+      case 'ws':
+        return this.websocketHandler(context, limit, ttl);
     }
   }
 
@@ -99,6 +101,6 @@ export class ThrottlerGuard implements CanActivate {
 
   private generateKey(context: ExecutionContext, prefix: string): string {
     const suffix = `${context.getClass().name}-${context.getHandler().name}`;
-    return md5(`${prefix}-${suffix}`)
+    return md5(`${prefix}-${suffix}`);
   }
 }

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -19,6 +19,11 @@ export class ThrottlerGuard implements CanActivate {
     private readonly reflector: Reflector,
   ) {}
 
+  /**
+   * Throttle requests against their TTL limit and whether to allow or deny it.
+   * Based on the context type different handlers will be called.
+   * @throws ThrottlerException
+   */
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const req = context.switchToHttp().getRequest();
     const handler = context.getHandler();
@@ -62,6 +67,12 @@ export class ThrottlerGuard implements CanActivate {
     }
   }
 
+  /**
+   * Throttles incoming HTTP requests.
+   * All the outgoing requests will contain RFC-compatible RateLimit headers.
+   * @see https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html#header-specifications
+   * @throws ThrottlerException
+   */
   private httpHandler(context: ExecutionContext, limit: number, ttl: number): boolean {
     const headerPrefix = 'X-RateLimit';
 
@@ -88,6 +99,10 @@ export class ThrottlerGuard implements CanActivate {
     return true;
   }
 
+  /**
+   * Throttles websocket requests. Both socket.io and websockets are supported.
+   * @throws ThrottlerException
+   */
   private websocketHandler(context: ExecutionContext, limit: number, ttl: number): boolean {
     const client = context.switchToWs().getClient();
     const ip = ['conn', '_socket']
@@ -105,8 +120,12 @@ export class ThrottlerGuard implements CanActivate {
     return true;
   }
 
-  private generateKey(context: ExecutionContext, prefix: string): string {
-    const suffix = `${context.getClass().name}-${context.getHandler().name}`;
+  /**
+   * Generate a hashed key that will be used as a storage key.
+   * The key will always be a combination of the current context and IP.
+   */
+  private generateKey(context: ExecutionContext, suffix: string): string {
+    const prefix = `${context.getClass().name}-${context.getHandler().name}`;
     return md5(`${prefix}-${suffix}`);
   }
 }

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -141,8 +141,8 @@ export class ThrottlerGuard implements CanActivate {
     ttl: number,
   ): Promise<boolean> {
     const { req, res } = context.getArgByIndex(2);
-    // add in escape route for GQL Fastify
-    // and for if res is not added to the context.
+    // Add in escape route for GQL Fastify.
+    // And if res is not added to the context.
     if (!res) {
       return true;
     }

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -141,8 +141,7 @@ export class ThrottlerGuard implements CanActivate {
     ttl: number,
   ): Promise<boolean> {
     const { req, res } = context.getArgByIndex(2);
-    // Add in escape route for GQL Fastify.
-    // And if res is not added to the context.
+    // Return early for GQL Fastify or if the res doesn't exist.
     if (!res) {
       return true;
     }

--- a/src/throttler.interface.ts
+++ b/src/throttler.interface.ts
@@ -10,6 +10,11 @@ export interface ThrottlerOptions {
   ttl?: number;
 
   /**
+   * The user agents that should be ignored. Checked against the `User-Agent` header
+   */
+  ignoreUserAgents?: RegExp[];
+
+  /**
    * The storage class to use where all the record will be stored in.
    */
   storage?: any;

--- a/src/throttler.interface.ts
+++ b/src/throttler.interface.ts
@@ -1,8 +1,18 @@
 import { ThrottlerStorage } from './throttler-storage.interface';
 
 export interface ThrottlerOptions {
-  limit: number;
-  ttl: number;
-  ignoreUserAgents?: RegExp[];
+  /**
+   * The amount of requests that are allowed within the ttl's time window.
+   */
+  limit?: number;
+
+  /**
+   * The amount of seconds of how many requests are allowed within this time.
+   */
+  ttl?: number;
+
+  /**
+   * The storage class to use where all the record will be stored in.
+   */
   storage?: ThrottlerStorage;
 }

--- a/src/throttler.interface.ts
+++ b/src/throttler.interface.ts
@@ -1,5 +1,3 @@
-import { ThrottlerStorage } from './throttler-storage.interface';
-
 export interface ThrottlerOptions {
   /**
    * The amount of requests that are allowed within the ttl's time window.
@@ -14,5 +12,5 @@ export interface ThrottlerOptions {
   /**
    * The storage class to use where all the record will be stored in.
    */
-  storage?: ThrottlerStorage;
+  storage?: any;
 }

--- a/src/throttler.module.ts
+++ b/src/throttler.module.ts
@@ -7,11 +7,17 @@ import { ThrottlerOptions } from './throttler.interface';
   exports: [ThrottlerCoreModule],
 })
 export class ThrottlerModule {
-  static forRoot(options: ThrottlerOptions) {
+  /**
+   * Register the module synchronously.
+   */
+  static forRoot(options?: ThrottlerOptions) {
     return ThrottlerCoreModule.forRoot(ThrottlerCoreModule, options);
   }
 
-  static forRootAsync(options: AsyncModuleConfig<ThrottlerOptions>) {
+  /**
+   * Register the module asynchronously.
+   */
+  static forRootAsync(options?: AsyncModuleConfig<ThrottlerOptions>) {
     return ThrottlerCoreModule.forRootAsync(ThrottlerCoreModule, options);
   }
 }

--- a/src/throttler.service.ts
+++ b/src/throttler.service.ts
@@ -5,7 +5,7 @@ import { ThrottlerStorage } from './throttler-storage.interface';
 export class ThrottlerStorageService implements ThrottlerStorage {
   storage: Record<string, number[]> = {};
 
-  async getRecord(key: string): Promise<number[]> {
+  getRecord(key: string): number[] {
     return this.storage[key] || [];
   }
 

--- a/src/throttler.service.ts
+++ b/src/throttler.service.ts
@@ -5,7 +5,7 @@ import { ThrottlerStorage } from './throttler-storage.interface';
 export class ThrottlerStorageService implements ThrottlerStorage {
   storage: Record<string, number[]> = {};
 
-  getRecord(key: string): number[] {
+  async getRecord(key: string): Promise<number[]> {
     return this.storage[key] || [];
   }
 

--- a/test/app/gateways/app.gateway.ts
+++ b/test/app/gateways/app.gateway.ts
@@ -1,23 +1,28 @@
-import { WebSocketGateway, SubscribeMessage } from '@nestjs/websockets';
+import { UseGuards } from '@nestjs/common';
+import { SubscribeMessage, WebSocketGateway } from '@nestjs/websockets';
+import { SkipThrottle, Throttle, ThrottlerGuard } from '../../../src';
 import { AppService } from '../app.service';
-import { SkipThrottle, Throttle } from '../../../src';
 
 @Throttle(2, 10)
 @WebSocketGateway({ path: '/' })
 export class AppGateway {
   constructor(private readonly appService: AppService) {}
+
+  @UseGuards(ThrottlerGuard)
   @SubscribeMessage('throttle-regular')
   pass() {
     return this.appService.success();
   }
 
   @SkipThrottle()
+  @UseGuards(ThrottlerGuard)
   @SubscribeMessage('ignore')
   ignore() {
     return this.appService.ignored();
   }
 
   @Throttle(5, 20)
+  @UseGuards(ThrottlerGuard)
   @SubscribeMessage('throttle-override')
   throttleOverride() {
     return this.appService.success();

--- a/test/app/gateways/app.gateway.ts
+++ b/test/app/gateways/app.gateway.ts
@@ -4,7 +4,7 @@ import { SkipThrottle, Throttle, ThrottlerGuard } from '../../../src';
 import { AppService } from '../app.service';
 
 @Throttle(2, 10)
-@WebSocketGateway({ path: '/' })
+@WebSocketGateway()
 export class AppGateway {
   constructor(private readonly appService: AppService) {}
 

--- a/test/app/gateways/default.gateway.ts
+++ b/test/app/gateways/default.gateway.ts
@@ -4,6 +4,7 @@ import { AppService } from '../app.service';
 @WebSocketGateway({ path: 'default' })
 export class DefaultGateway {
   constructor(private readonly appService: AppService) {}
+
   @SubscribeMessage('throttle-regular')
   pass() {
     return this.appService.success();

--- a/test/app/gateways/default.gateway.ts
+++ b/test/app/gateways/default.gateway.ts
@@ -1,11 +1,11 @@
 import { WebSocketGateway, SubscribeMessage } from '@nestjs/websockets';
 import { AppService } from '../app.service';
 
-@WebSocketGateway({ path: 'default' })
+@WebSocketGateway()
 export class DefaultGateway {
   constructor(private readonly appService: AppService) {}
 
-  @SubscribeMessage('throttle-regular')
+  @SubscribeMessage('default-regular')
   pass() {
     return this.appService.success();
   }

--- a/test/app/gateways/limit.gateway.ts
+++ b/test/app/gateways/limit.gateway.ts
@@ -1,11 +1,12 @@
-import { WebSocketGateway, SubscribeMessage } from '@nestjs/websockets';
-import { AppService } from '../app.service';
+import { SubscribeMessage, WebSocketGateway } from '@nestjs/websockets';
 import { Throttle } from '../../../src';
+import { AppService } from '../app.service';
 
 @Throttle(2, 10)
 @WebSocketGateway({ path: 'limit' })
 export class LimitGateway {
   constructor(private readonly appService: AppService) {}
+
   @SubscribeMessage('throttle-regular')
   pass() {
     return this.appService.success();

--- a/test/app/gateways/limit.gateway.ts
+++ b/test/app/gateways/limit.gateway.ts
@@ -1,8 +1,10 @@
 import { SubscribeMessage, WebSocketGateway } from '@nestjs/websockets';
-import { Throttle } from '../../../src';
+import { Throttle, ThrottlerGuard } from '../../../src';
 import { AppService } from '../app.service';
+import { UseGuards } from '@nestjs/common';
 
 @Throttle(2, 10)
+@UseGuards(ThrottlerGuard)
 @WebSocketGateway()
 export class LimitGateway {
   constructor(private readonly appService: AppService) {}

--- a/test/app/gateways/limit.gateway.ts
+++ b/test/app/gateways/limit.gateway.ts
@@ -3,17 +3,17 @@ import { Throttle } from '../../../src';
 import { AppService } from '../app.service';
 
 @Throttle(2, 10)
-@WebSocketGateway({ path: 'limit' })
+@WebSocketGateway()
 export class LimitGateway {
   constructor(private readonly appService: AppService) {}
 
-  @SubscribeMessage('throttle-regular')
+  @SubscribeMessage('limit-regular')
   pass() {
     return this.appService.success();
   }
 
   @Throttle(5, 20)
-  @SubscribeMessage('throttle-override')
+  @SubscribeMessage('limit-override')
   throttleOverride() {
     return this.appService.success();
   }

--- a/test/app/main.ts
+++ b/test/app/main.ts
@@ -1,13 +1,14 @@
 import { NestFactory } from '@nestjs/core';
-import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { ExpressAdapter } from '@nestjs/platform-express';
+// import { FastifyAdapter } from '@nestjs/platform-fastify';
 import { WsAdapter } from '@nestjs/platform-ws';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(
     AppModule,
-    // new ExpressAdapter(),
-    new FastifyAdapter(),
+    new ExpressAdapter(),
+    // new FastifyAdapter(),
   );
   app.useWebSocketAdapter(new WsAdapter(app));
   await app.listen(3000);

--- a/test/app/main.ts
+++ b/test/app/main.ts
@@ -1,6 +1,5 @@
 import { NestFactory } from '@nestjs/core';
 import { ExpressAdapter } from '@nestjs/platform-express';
-import { WsAdapter } from '@nestjs/platform-ws';
 // import { FastifyAdapter } from '@nestjs/platform-fastify';
 import { WsAdapter } from '@nestjs/platform-ws';
 import { AppModule } from './app.module';

--- a/test/app/main.ts
+++ b/test/app/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { ExpressAdapter } from '@nestjs/platform-express';
+import { WsAdapter } from '@nestjs/platform-ws';
 // import { FastifyAdapter } from '@nestjs/platform-fastify';
 import { WsAdapter } from '@nestjs/platform-ws';
 import { AppModule } from './app.module';

--- a/test/app/resolvers/app.resolver.ts
+++ b/test/app/resolvers/app.resolver.ts
@@ -1,7 +1,9 @@
-import { Resolver, Query, Mutation } from '@nestjs/graphql';
-import { ResolveType } from './resolve.model';
+import { Mutation, Query, Resolver } from '@nestjs/graphql';
 import { AppService } from '../app.service';
+import { ResolveType } from './resolve.model';
+import { Throttle } from '../../../src';
 
+@Throttle(2, 10)
 @Resolver(ResolveType)
 export class AppResolver {
   constructor(private readonly appService: AppService) {}

--- a/test/app/resolvers/app.resolver.ts
+++ b/test/app/resolvers/app.resolver.ts
@@ -1,5 +1,18 @@
-import { Resolver } from '@nestjs/graphql';
+import { Resolver, Query, Mutation } from '@nestjs/graphql';
 import { ResolveType } from './resolve.model';
+import { AppService } from '../app.service';
 
 @Resolver(ResolveType)
-export class AppResolver {}
+export class AppResolver {
+  constructor(private readonly appService: AppService) {}
+
+  @Query(() => ResolveType)
+  appQuery() {
+    return this.appService.success();
+  }
+
+  @Mutation(() => ResolveType)
+  appMutation() {
+    return this.appService.success();
+  }
+}

--- a/test/app/resolvers/default.resolver.ts
+++ b/test/app/resolvers/default.resolver.ts
@@ -1,5 +1,18 @@
-import { Resolver } from '@nestjs/graphql';
+import { Mutation, Query, Resolver } from '@nestjs/graphql';
+import { AppService } from '../app.service';
 import { ResolveType } from './resolve.model';
 
 @Resolver(ResolveType)
-export class DefaultResolver {}
+export class DefaultResolver {
+  constructor(private readonly appService: AppService) {}
+
+  @Query(() => ResolveType)
+  defaultQuery() {
+    return this.appService.success();
+  }
+
+  @Mutation(() => ResolveType)
+  defaultMutation() {
+    return this.appService.success();
+  }
+}

--- a/test/app/resolvers/limit.resolver.ts
+++ b/test/app/resolvers/limit.resolver.ts
@@ -1,5 +1,20 @@
-import { Resolver } from '@nestjs/graphql';
+import { Mutation, Query, Resolver } from '@nestjs/graphql';
+import { Throttle } from '../../../src';
+import { AppService } from '../app.service';
 import { ResolveType } from './resolve.model';
 
 @Resolver(ResolveType)
-export class LimitResolver {}
+export class LimitResolver {
+  constructor(private readonly appService: AppService) {}
+
+  @Query(() => ResolveType)
+  limitQuery() {
+    return this.appService.success();
+  }
+
+  @Throttle(2, 10)
+  @Mutation(() => ResolveType)
+  limitMutation() {
+    return this.appService.success();
+  }
+}

--- a/test/app/resolvers/resolve.model.ts
+++ b/test/app/resolvers/resolve.model.ts
@@ -2,6 +2,6 @@ import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType()
 export class ResolveType {
-  @Field((type) => Boolean)
+  @Field(() => Boolean)
   success = true;
 }

--- a/test/app/resolvers/resolve.model.ts
+++ b/test/app/resolvers/resolve.model.ts
@@ -2,6 +2,6 @@ import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType()
 export class ResolveType {
-  @Field()
+  @Field((type) => Boolean)
   success = true;
 }

--- a/test/app/resolvers/resolver.module.ts
+++ b/test/app/resolvers/resolver.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ThrottlerModule } from '../../../src';
+import { AppService } from '../app.service';
 import { AppResolver } from './app.resolver';
 import { DefaultResolver } from './default.resolver';
 import { LimitResolver } from './limit.resolver';
@@ -11,6 +12,6 @@ import { LimitResolver } from './limit.resolver';
       ttl: 60,
     }),
   ],
-  providers: [AppResolver, DefaultResolver, LimitResolver],
+  providers: [AppResolver, DefaultResolver, LimitResolver, AppService],
 })
 export class ResolverModule {}

--- a/test/gateway.e2e-spec.ts
+++ b/test/gateway.e2e-spec.ts
@@ -1,11 +1,9 @@
-import { WebSocketAdapter, INestApplication, Type } from '@nestjs/common';
+import { INestApplication, Type, WebSocketAdapter } from '@nestjs/common';
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { WsAdapter } from '@nestjs/platform-ws';
 import { Test } from '@nestjs/testing';
 import * as Io from 'socket.io-client';
-import { createConnection, wsClose, wsPromise } from './utility/ws-promise';
 import { GatewayModule } from './app/gateways/gateway.module';
-
 describe.each`
   adapter      | server         | client                                 | protocol  | sendMethod | serializer                                                 | deserializer
   ${IoAdapter} | ${'Socket.io'} | ${(url: string) => Io(url)}            | ${'http'} | ${'emit'}  | ${(message: string) => message}                            | ${(message: string) => JSON.parse(message)}

--- a/test/gateway.e2e-spec.ts
+++ b/test/gateway.e2e-spec.ts
@@ -115,7 +115,7 @@ describe.each`
               const res = await wsPromise(ws, serializer(message), sendMethod);
               expect(res).toEqual(deserializer(JSON.stringify(expectation)));
             }
-            // only using Socket.IO for the error test due to a problem ith catching exceptions in WS
+            // only using Socket.IO for the error test due to a problem w/ catching exceptions in WS
             if (server === 'Socket.io') {
               const errorRes = await wsPromise(ws, serializer(message), sendMethod);
               expect(errorRes).toEqual({

--- a/test/resolver.e2e-spec.ts
+++ b/test/resolver.e2e-spec.ts
@@ -1,1 +1,96 @@
-it.todo('implement gql tests');
+import { INestApplication } from '@nestjs/common';
+import { AbstractHttpAdapter, APP_GUARD } from '@nestjs/core';
+import { GraphQLModule } from '@nestjs/graphql';
+import { ExpressAdapter } from '@nestjs/platform-express';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerGuard } from '../src';
+import { ResolverModule } from './app/resolvers/resolver.module';
+import { httPromise } from './utility/httpromise';
+
+function queryFactory(prefix: string): Record<string, any> {
+  return {
+    query: `query ${prefix}Query{ ${prefix}Query{ success }}`,
+  };
+}
+
+function mutationFactory(prefix: string): Record<string, any> {
+  return {
+    query: `mutation ${prefix}Mutation{ ${prefix}Mutation{ success }}`,
+  };
+}
+
+describe.each`
+  adapter                 | adapterName  | context
+  ${new ExpressAdapter()} | ${'Express'} | ${({ req, res }) => ({ req, res })}
+  ${new FastifyAdapter()} | ${'Fastify'} | ${({}) => ({})}
+`(
+  '$adapterName Throttler',
+  ({ adapter, context }: { adapter: AbstractHttpAdapter; context: () => any }) => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+      const moduleFixture: TestingModule = await Test.createTestingModule({
+        imports: [
+          ResolverModule,
+          GraphQLModule.forRoot({
+            autoSchemaFile: true,
+            context,
+          }),
+        ],
+        providers: [
+          {
+            provide: APP_GUARD,
+            useClass: ThrottlerGuard,
+          },
+        ],
+      }).compile();
+
+      app = moduleFixture.createNestApplication(adapter);
+      await app.listen(0);
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    describe('Resolvers', () => {
+      let appUrl: string;
+      beforeAll(async () => {
+        appUrl = (await app.getUrl()) + '/graphql';
+      });
+
+      /**
+       * Tests for setting `@Throttle()` at the method level and for ignore routes
+       */
+      describe('AppResolver', () => {
+        it.todo('Implement AppResolver tests');
+        it.each`
+          type
+          ${'query'}
+          ${'mutation'}
+        `('$type', async ({ type }: { type: string }) => {
+          const res = await httPromise(
+            appUrl,
+            'POST',
+            {},
+            type === 'query' ? queryFactory('app') : mutationFactory('app'),
+          );
+          expect(res).toEqual({ success: true });
+        });
+      });
+      /**
+       * Tests for setting `@Throttle()` at the class level and overriding at the method level
+       */
+      describe('LimitResolver', () => {
+        it.todo('Implement LimitResolver test');
+      });
+      /**
+       * Tests for setting throttle values at the `forRoot` level
+       */
+      describe('DefaultResolver', () => {
+        it.todo('implement DefaultResolver Test');
+      });
+    });
+  },
+);

--- a/test/resolver.e2e-spec.ts
+++ b/test/resolver.e2e-spec.ts
@@ -2,28 +2,39 @@ import { INestApplication } from '@nestjs/common';
 import { AbstractHttpAdapter, APP_GUARD } from '@nestjs/core';
 import { GraphQLModule } from '@nestjs/graphql';
 import { ExpressAdapter } from '@nestjs/platform-express';
-import { FastifyAdapter } from '@nestjs/platform-fastify';
+// import { FastifyAdapter } from '@nestjs/platform-fastify';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ThrottlerGuard } from '../src';
 import { ResolverModule } from './app/resolvers/resolver.module';
 import { httPromise } from './utility/httpromise';
 
-function queryFactory(prefix: string): Record<string, any> {
-  return {
-    query: `query ${prefix}Query{ ${prefix}Query{ success }}`,
-  };
-}
+const factories = {
+  query: (prefix: string): Record<string, any> => {
+    return {
+      query: `query ${prefix}Query{ ${prefix}Query{ success }}`,
+    };
+  },
+  mutation: (prefix: string): Record<string, any> => {
+    return {
+      query: `mutation ${prefix}Mutation{ ${prefix}Mutation{ success }}`,
+    };
+  },
+  data: (prefix: string, type: string): Record<string, any> => {
+    type = type[0].toUpperCase() + type.substring(1, type.length);
+    return {
+      data: {
+        [prefix + type]: {
+          success: true,
+        },
+      },
+    };
+  },
+};
 
-function mutationFactory(prefix: string): Record<string, any> {
-  return {
-    query: `mutation ${prefix}Mutation{ ${prefix}Mutation{ success }}`,
-  };
-}
-
+// ${new FastifyAdapter()} | ${'Fastify'} | ${() => ({})}
 describe.each`
   adapter                 | adapterName  | context
   ${new ExpressAdapter()} | ${'Express'} | ${({ req, res }) => ({ req, res })}
-  ${new FastifyAdapter()} | ${'Fastify'} | ${({}) => ({})}
 `(
   '$adapterName Throttler',
   ({ adapter, context }: { adapter: AbstractHttpAdapter; context: () => any }) => {
@@ -64,32 +75,64 @@ describe.each`
        * Tests for setting `@Throttle()` at the method level and for ignore routes
        */
       describe('AppResolver', () => {
-        it.todo('Implement AppResolver tests');
         it.each`
           type
           ${'query'}
           ${'mutation'}
         `('$type', async ({ type }: { type: string }) => {
-          const res = await httPromise(
-            appUrl,
-            'POST',
-            {},
-            type === 'query' ? queryFactory('app') : mutationFactory('app'),
-          );
-          expect(res).toEqual({ success: true });
+          const res = await httPromise(appUrl, 'POST', {}, factories[type]('app'));
+          expect(res.data).toEqual(factories.data('app', type));
+          expect(res.headers).toMatchObject({
+            'x-ratelimit-limit': '2',
+            'x-ratelimit-remaining': '1',
+            'x-ratelimit-reset': /\d+/,
+          });
         });
       });
       /**
        * Tests for setting `@Throttle()` at the class level and overriding at the method level
        */
       describe('LimitResolver', () => {
-        it.todo('Implement LimitResolver test');
+        it.each`
+          type          | limit
+          ${'query'}    | ${5}
+          ${'mutation'} | ${2}
+        `('$type', async ({ type, limit }: { type: string; limit: number }) => {
+          for (let i = 0; i < limit; i++) {
+            const res = await httPromise(appUrl, 'POST', {}, factories[type]('limit'));
+            expect(res.data).toEqual(factories.data('limit', type));
+            expect(res.headers).toMatchObject({
+              'x-ratelimit-limit': limit.toString(),
+              'x-ratelimit-remaining': (limit - (i + 1)).toString(),
+              'x-ratelimit-reset': /\d+/,
+            });
+          }
+          const errRes = await httPromise(appUrl, 'POST', {}, factories[type]('limit'));
+          expect(errRes.data).not.toEqual(factories.data('limit', type));
+          expect(errRes.data.errors[0].message).toBe('ThrottlerException: Too Many Requests');
+          expect(errRes.headers).toMatchObject({
+            'retry-after': /\d+/,
+          });
+          expect(errRes.status).toBe(200);
+        });
       });
       /**
        * Tests for setting throttle values at the `forRoot` level
        */
       describe('DefaultResolver', () => {
-        it.todo('implement DefaultResolver Test');
+        it.each`
+          type
+          ${'query'}
+          ${'mutation'}
+        `('$type', async ({ type }: { type: string }) => {
+          const res = await httPromise(appUrl, 'POST', {}, factories[type]('default'));
+          expect(res.data).toEqual(factories.data('default', type));
+          expect(res.headers).toMatchObject({
+            'x-ratelimit-limit': '5',
+            'x-ratelimit-remaining': '4',
+            'x-ratelimit-reset': /\d+/,
+          });
+        });
       });
     });
   },

--- a/test/utility/ws-promise.ts
+++ b/test/utility/ws-promise.ts
@@ -9,6 +9,7 @@ export const createConnection = (
     if (Object.getOwnPropertyDescriptor(socket, 'io')) {
       resolve(socket);
     }
+    (socket as WebSocket).setMaxListeners(15);
     socket.on('open', () => {
       resolve(socket);
     });
@@ -28,9 +29,6 @@ export const wsPromise = (
         resolve(data);
       }
     });
-    ws.addEventListener('exception' as any, (...args) => {
-      resolve(args);
-    });
     ws.on('message', (data) => {
       resolve(data);
       return false;
@@ -39,7 +37,9 @@ export const wsPromise = (
       console.error(err);
       reject(err);
     });
-
+    ws.on('exception' as any, (...args) => {
+      resolve(args);
+    });
     ws.on('unexpected-response', () => {
       reject('Unexpected-response');
     });

--- a/test/utility/ws-promise.ts
+++ b/test/utility/ws-promise.ts
@@ -28,6 +28,9 @@ export const wsPromise = (
         resolve(data);
       }
     });
+    ws.addEventListener('exception' as any, (...args) => {
+      resolve(args);
+    });
     ws.on('message', (data) => {
       resolve(data);
       return false;
@@ -36,9 +39,7 @@ export const wsPromise = (
       console.error(err);
       reject(err);
     });
-    ws.on('exception' as any, (...args) => {
-      resolve(args);
-    });
+
     ws.on('unexpected-response', () => {
       reject('Unexpected-response');
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,7 +1331,7 @@
     socket.io "2.3.0"
     tslib "2.0.0"
 
-"@nestjs/platform-ws@^7.1.2":
+"@nestjs/platform-ws@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@nestjs/platform-ws/-/platform-ws-7.1.3.tgz#870fa693e8079da0580381ff7273c5b4e8b18e17"
   integrity sha512-j39uLmas16d1ud8rqZn6cs9mxsIZ87DluWr0860dgY2GATRoa+QBm6FTzJ1d738g94CMowLACHhBqg0q+eSLug==
@@ -11316,7 +11316,7 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@7.3.0, ws@^7.1.2, ws@^7.2.3:
+ws@7.3.0, ws@^7.0.0, ws@^7.1.2, ws@^7.3.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
   integrity sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2487,6 +2487,19 @@ apollo-server-express@^2.14.3:
     subscriptions-transport-ws "^0.9.16"
     type-is "^1.6.16"
 
+apollo-server-fastify@^2.14.3:
+  version "2.14.3"
+  resolved "https://registry.yarnpkg.com/apollo-server-fastify/-/apollo-server-fastify-2.14.3.tgz#633992f81dd70c288c8f53c4d77eb0c29bdf756e"
+  integrity sha512-qihLp9VUDxM/NZOpmdyCKp4/oq43tKf3aX94us4inbHIBu2lPCpREe4toJZL+9M45TQ2oTKF18gtlx3QEEtw7g==
+  dependencies:
+    "@apollographql/graphql-playground-html" "1.6.24"
+    apollo-server-core "^2.14.3"
+    apollo-server-types "^0.5.0"
+    fastify-accepts "^1.0.0"
+    fastify-cors "^0.2.0"
+    graphql-subscriptions "^1.0.0"
+    graphql-tools "^4.0.0"
+
 apollo-server-plugin-base@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-0.9.0.tgz#777f720a1ee827a66b8c159073ca30645f8bc625"
@@ -5100,12 +5113,28 @@ fast-safe-stringify@2.0.7, fast-safe-stringify@^2.0.7:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
 
+fastify-accepts@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fastify-accepts/-/fastify-accepts-1.0.0.tgz#8475d1e4c4eaf777eb916144ddc904f92d3c726a"
+  integrity sha512-JVI/zKXjVfwIAdXDZvNKM7CCEWkbTFSZQUEQxrH4KBprbopGxq3R4RSIsVxqhdkVanm90yyVcPtgEa2MnDwPyg==
+  dependencies:
+    accepts "^1.3.5"
+    fastify-plugin "^1.2.0"
+
 fastify-cors@3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/fastify-cors/-/fastify-cors-3.0.3.tgz#c1b2227983d7b02feff73fd642d81041adfbe124"
   integrity sha512-SDMa+GtyTTAU7pWZwY4fukb/VwCZ4c30p0oEaE7/d/+VCvceB1+NzW2udp2dSZZfWR7J1kUookCpw2dLmtAsSw==
   dependencies:
     fastify-plugin "^1.6.0"
+    vary "^1.1.2"
+
+fastify-cors@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/fastify-cors/-/fastify-cors-0.2.0.tgz#8fce0a2a5ba05ac08c7d6f2ca4c501b0ae638e39"
+  integrity sha512-bw14FmjHm8oF4TDLkwj2TpssH6O2gE0NpsRqLe7F1Gh9Jf30Lx9ZzIznhqaAKOYS+LJqLIt5snurv7urgqYntA==
+  dependencies:
+    fastify-plugin "^1.2.0"
     vary "^1.1.2"
 
 fastify-formbody@3.2.0:
@@ -5116,7 +5145,7 @@ fastify-formbody@3.2.0:
     fastify-plugin "^1.6.1"
     qs "^6.9.4"
 
-fastify-plugin@^1.6.0, fastify-plugin@^1.6.1:
+fastify-plugin@^1.2.0, fastify-plugin@^1.6.0, fastify-plugin@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-1.6.1.tgz#122f5a5eeb630d55c301713145a9d188e6d5dd5b"
   integrity sha512-APBcb27s+MjaBIerFirYmBLatoPCgmHZM6XP0K+nDL9k0yX8NJPWDY1RAC3bh6z+AB5ULS2j31BUfLMT3uaZ4A==


### PR DESCRIPTION
Adds in the functionality to work with Websockets and GraphQL when it comes to request throttling. As there is no official RFC for websockets throttling, this acts the same as the current functionality. Includes doc updates about how to use with both GQL and WS.