### PR TITLE
feat(ws): allows for optional use of @nestjs/websocket

### DIFF
--- a/src/throttler-ws.exception.ts
+++ b/src/throttler-ws.exception.ts
@@ -1,0 +1,15 @@
+import { loadPackage } from '@nestjs/common/utils/load-package.util';
+import { message } from './throttler.exception';
+
+export const { WsException } = loadPackage('@nestjs/websockets', 'ThrottlerWsException');
+
+/**
+ * Throws a WsException indicating that too many requests were being fired
+ * within a certain time window.
+ * @publicApi
+ */
+export class ThrottlerWsException extends WsException {
+  constructor() {
+    super(`ThrottlerWsException: ${message}`);
+  }
+}

--- a/src/throttler.exception.ts
+++ b/src/throttler.exception.ts
@@ -1,7 +1,6 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
-import { WsException } from '@nestjs/websockets';
 
-const message = 'Too Many Requests';
+export const message = 'Too Many Requests';
 
 /**
  * Throws a HttpException with a 429 status code, indicating that too many
@@ -11,16 +10,5 @@ const message = 'Too Many Requests';
 export class ThrottlerException extends HttpException {
   constructor() {
     super(`ThrottlerException: ${message}`, HttpStatus.TOO_MANY_REQUESTS);
-  }
-}
-
-/**
- * Throws a WsException indicating that too many requests were being fired
- * within a certain time window.
- * @publicApi
- */
-export class ThrottlerWsException extends WsException {
-  constructor() {
-    super(`ThrottlerWsException: ${message}`);
   }
 }

--- a/src/throttler.guard.spec.ts
+++ b/src/throttler.guard.spec.ts
@@ -1,10 +1,11 @@
+import { ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
 import { ThrottlerStorage } from './throttler-storage.interface';
+import { ThrottlerWsException } from './throttler-ws.exception';
 import { THROTTLER_OPTIONS } from './throttler.constants';
+import { ThrottlerException } from './throttler.exception';
 import { ThrottlerGuard } from './throttler.guard';
-import { ExecutionContext } from '@nestjs/common';
-import { ThrottlerException, ThrottlerWsException } from './throttler.exception';
 
 class ThrottlerStorageServiceMock implements ThrottlerStorage {
   private _storage: Record<string, number[]> = {};

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,3 +1,0 @@
-import { ThrottlerStorage } from './throttler-storage.interface';
-
-export type Type<T extends ThrottlerStorage> = { new (...args: any[]): T };


### PR DESCRIPTION
Adds the ability to **not** use `@nestjs/websockets` but still have the module work in general.

@kkoomen can you verify that this is doing what I think it is. Tests pass, and a local check passed, but having another dev look it over would be really nice.